### PR TITLE
added optional password

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -1,5 +1,5 @@
 {
-  "pluginAlias": "lutron-hwi",
+  "pluginAlias": "lutron-hwi-ajs",
   "pluginType": "platform",
   "singular": true,
   "schema": {
@@ -36,6 +36,10 @@
         "title": "Telnet Port",
         "type": "integer",
         "required": true
+      },
+      "password": {
+        "title": "Optional User,Pass",
+        "type": "string"
       },
       "minInterCmdTime": {
         "title": "Minimum delay between telnet commands (ms)",

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,5 +1,5 @@
 {
-  "pluginAlias": "lutron-hwi-ajs",
+  "pluginAlias": "lutron-hwi",
   "pluginType": "platform",
   "singular": true,
   "schema": {

--- a/src/lutronTelnet.ts
+++ b/src/lutronTelnet.ts
@@ -63,6 +63,7 @@ type LutronTelnetOptions = {
     telnetIP: string;
     telnetPort: number;
     minCmdDelay: number;
+    password: string;
 };
 
 type OutHandlerCB = (OutputType, Array) => void;
@@ -86,6 +87,7 @@ export class LutronTelnet {
   private minCmdDelay = 200;
 
   private ipAdr = '';
+  private password= '';
   private port = 0;
 
   private ipcCounter = 0;
@@ -99,6 +101,9 @@ export class LutronTelnet {
     if (opts !== undefined) {
       if (opts.telnetIP !== undefined) {
         this.ipAdr = opts.telnetIP;
+      }
+      if (opts.password!== undefined) {
+        this.password = opts.password;
       }
       if (opts.telnetPort !== undefined) {
         this.port = opts.telnetPort;
@@ -187,7 +192,7 @@ export class LutronTelnet {
       await this.connection.connect(params);
       this.connected = true;
 
-      this.telnetSend('', Priority.High);       // just CR to bring up the prompt
+      this.telnetSend(this.password, Priority.High);       // just CR to bring up the prompt
       this.telnetSend('DLMON', Priority.High);  // ensure monitoring of dimmer-level changes
 
       this.connection.on('data', (buf) => {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -37,6 +37,7 @@ export class LutronHWIPlatform implements DynamicPlatformPlugin {
     this.lutronTelnet = new LutronTelnet(this, this.config.commMode, {
       telnetIP : this.config.telnetIP,
       telnetPort : this.config.telnetPort,
+      password: this.config.password,
       minCmdDelay : this.config.minInterCmdTime,
     });
 


### PR DESCRIPTION
I have a lutron system with a built in ethernet port that allows telnet. When you telnet it in gives you a prompt: 

LOGIN:

and expects user,password

I added an optional password to the first "linefeed", so I can just put: "myusername,mypassword" into the config, and it seems to work.